### PR TITLE
Fixes for source code build

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -23,6 +23,10 @@ my $builder = Alien::Base::ModuleBuild->new(
 		location => 'libxml2/',
 		pattern  => qr/^libxml2-([\d\.]+)\.tar\.gz$/,
 	},
+	alien_build_commands => [
+                '%pconfigure --prefix=%s --without-python --enable-shared --enable-static --with-pic',
+                'make',
+	],
 );
 $builder->create_build_script;
 

--- a/Build.PL
+++ b/Build.PL
@@ -21,7 +21,7 @@ my $builder = Alien::Base::ModuleBuild->new(
 		protocol => 'ftp',
 		host     => 'xmlsoft.org',
 		location => 'libxml2/',
-		pattern  => qr/^libxml2-sources-([\d\.]+)\.tar\.gz$/,
+		pattern  => qr/^libxml2-([\d\.]+)\.tar\.gz$/,
 	},
 );
 $builder->create_build_script;

--- a/t/01-compiler.t
+++ b/t/01-compiler.t
@@ -28,6 +28,8 @@ sub file ($) { File::Spec->catfile(split m{/}, $_[0]) }
 my @libs   = shellwords( Alien::LibXML->libs );
 my @cflags = shellwords( Alien::LibXML->cflags );
 
+@libs = map { $_ =~ /^-L(.*)$/ && -d File::Spec->catdir($1, '.libs') ? ($_, "-L" . File::Spec->catdir($1, '.libs')) : $_ } @libs;
+
 diag "COMPILER: $CC";
 diag "CFLAGS:   @cflags";
 diag "LIBS:     @libs";


### PR DESCRIPTION
This fixes a number of issues with the source code build for Alien::LibXML.
1. Changes the pattern so that the latest version 2.9.1 is preferred over the older 2.9.0
2. Works around what may be a bug in libxml2's uninstalled .pc file by adding the .libs directory to the library search path (if it is found), note that this fixes rt#90273 reported last November.
3. Disables python in build, installing with the python enabled tried to install python libraries into system directories which usually fails for normal users.

I am one of the core `Alien::Base` developers, and am keen to see this library be more reliable.  If you don't have the time or interest in this dist, I'd be happy to take over for you.
