### PR TITLE
Alien::Base 0.005, static libs, support for windows.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,7 +13,7 @@ my $builder = Alien::Base::ModuleBuild->new(
 	},
 	requires => {
 		'perl'        => '5.8.9',
-		'Alien::Base' => '0',
+		'Alien::Base' => '0.005',
 	},
 	dist_author => 'Toby Inkster <tobyink@cpan.org>',
 	alien_name => 'libxml-2.0',
@@ -24,9 +24,10 @@ my $builder = Alien::Base::ModuleBuild->new(
 		pattern  => qr/^libxml2-([\d\.]+)\.tar\.gz$/,
 	},
 	alien_build_commands => [
-                '%pconfigure --prefix=%s --without-python --enable-shared --enable-static --with-pic',
+                '%c --prefix=%s --without-python --enable-shared --enable-static',
                 'make',
 	],
+	alien_isolate_dynamic => 1,
 );
 $builder->create_build_script;
 

--- a/t/01-compiler.t
+++ b/t/01-compiler.t
@@ -37,9 +37,10 @@ diag "OUTPUT:   @{[ file 't/tree1.exe' ]}";
 diag "INPUT:    @{[ file 't/tree1.c' ]}";
 
 system(
-	$CC, @cflags, @libs,
+	$CC, @cflags,
 	-o => file 't/tree1.exe',
 	      file 't/tree1.c',
+	@libs,
 );
 
 ok -x 't/tree1.exe';

--- a/t/01-compiler.t
+++ b/t/01-compiler.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Env qw( @PATH );
 
 BEGIN {
 	eval { require File::Which } or plan skip_all => 'need File::Which';
@@ -28,7 +29,12 @@ sub file ($) { File::Spec->catfile(split m{/}, $_[0]) }
 my @libs   = shellwords( Alien::LibXML->libs );
 my @cflags = shellwords( Alien::LibXML->cflags );
 
-@libs = map { $_ =~ /^-L(.*)$/ && -d File::Spec->catdir($1, '.libs') ? ($_, "-L" . File::Spec->catdir($1, '.libs')) : $_ } @libs;
+@libs = map { $_ =~ /^-L(.*)$/ && -d File::Spec->catfile($1, '.libs') ? ($_, "-L" . File::Spec->catfile($1, '.libs')) : $_ } @libs;
+
+if($^O eq 'MSWin32') {
+  # on windows, the dll must be in the PATH
+  push @PATH, $_ for map { my $p = $_; $p =~ s{^-L}{}; $p } grep { /^-L/ } @libs;
+}
 
 diag "COMPILER: $CC";
 diag "CFLAGS:   @cflags";


### PR DESCRIPTION
Working with RC for Alien::Base 0.005 I was able to get Alien::LibXML to install on Windows with these commits.  The RC an be found here:

https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-Base-0.004_05.tar.gz

This version will also likely be more reliable on non windows platforms since it uses static libraries when linking XS modules.
