### PR TITLE
use AB::MB as configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -7,7 +7,7 @@ my $builder = Alien::Base::ModuleBuild->new(
 	module_name => 'Alien::LibXML',
 	license => 'mit',
 	configure_requires => {
-		'Alien::Base'   => '0.001',
+		'Alien::Base::ModuleBuild'   => '0.001',
 		'Module::Build' => '0.38',
 	},
 	test_requires => {


### PR DESCRIPTION
For rationale please see https://github.com/Perl5-Alien/Alien-Base/issues/157
